### PR TITLE
Update Observer.php

### DIFF
--- a/app/code/community/C4B/Freeproduct/Model/Observer.php
+++ b/app/code/community/C4B/Freeproduct/Model/Observer.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 /**
  * Freeproduct Module


### PR DESCRIPTION
There was an **empty space** in front of the `<?php` opening tag  on line 1 causing a question mark to be displayed at the top of the page when there was a free gift in the basket.