### PR TITLE
Added ability to remove & ignore auto-added free products from the cart.

### DIFF
--- a/app/code/community/C4B/Freeproduct/Helper/Data.php
+++ b/app/code/community/C4B/Freeproduct/Helper/Data.php
@@ -20,6 +20,7 @@ class C4B_Freeproduct_Helper_Data extends Mage_Core_Helper_Abstract
             'freeproduct/item/delete',
             array(
                 'id'=>$_item->getId(),
+                'form_key'=> Mage::getSingleton('core/session')->getFormKey(),
                 Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => Mage::helper('core/url')->getEncodedUrl()
             )
         );

--- a/app/code/community/C4B/Freeproduct/Helper/Data.php
+++ b/app/code/community/C4B/Freeproduct/Helper/Data.php
@@ -15,4 +15,13 @@
  */
 class C4B_Freeproduct_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    public function getDeleteUrl($_item) {
+        return Mage::getModel('core/url')->getUrl(
+            'freeproduct/item/delete',
+            array(
+                'id'=>$_item->getId(),
+                Mage_Core_Controller_Front_Action::PARAM_NAME_URL_ENCODED => Mage::helper('core/url')->getEncodedUrl()
+            )
+        );
+    }
 }

--- a/app/code/community/C4B/Freeproduct/Model/Observer.php
+++ b/app/code/community/C4B/Freeproduct/Model/Observer.php
@@ -224,7 +224,20 @@ class C4B_Freeproduct_Model_Observer
             'code' => 'freeproduct_uniqid',
             'value' => uniqid(null, true)
         )));
-        
+
+        $quoteItem = static::_checkNotIgnored($quoteItem);
+
         return $quoteItem;
+    }
+
+    protected static function _checkNotIgnored($quoteItem) {
+        $session = Mage::getSingleton('checkout/session');
+        // uncomment to reset
+        // $session->setIgnoredFreeproducts(array());
+        $ignored = $session->getIgnoredFreeproducts();
+        if(!is_array($ignored)) $ignored= array();
+        if(in_array($quoteItem->getSku(), $ignored)) $quoteItem = null;
+        return $quoteItem;
+        
     }
 }

--- a/app/code/community/C4B/Freeproduct/controllers/ItemController.php
+++ b/app/code/community/C4B/Freeproduct/controllers/ItemController.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once(Mage::getModuleDir('controllers','Mage_Checkout').DS.'CartController.php');
+
+class C4B_Freeproduct_ItemController extends Mage_Checkout_CartController
+{
+
+    public function deleteAction() {
+        $quote = $this->_getQuote();
+        $session = $this->_getSession();
+        $id = (int) $this->getRequest()->getParam('id');
+
+        if($id) {
+            try {
+                $item = $quote->getItemById($id);
+                if ($item && $item->getIsFreeProduct()) {
+                    //$rule = $item->getApplyingRule();
+                    //$rule->setIsApplied(true);
+                    $ignored = $session->getIgnoredFreeproducts();
+                    if(!is_array($ignored)) $ignored= array();
+                    $ignored[] = $item->getSku();
+                    $session->setIgnoredFreeproducts(array_unique($ignored));
+                }
+            } catch (Exception $e) {
+                $this->_getSession()->addError($this->__('Cannot remove the item.'));
+                Mage::logException($e);
+            }
+        }
+        parent::deleteAction();
+    }
+
+}

--- a/app/code/community/C4B/Freeproduct/etc/config.xml
+++ b/app/code/community/C4B/Freeproduct/etc/config.xml
@@ -109,6 +109,23 @@
                     </freeproduct>
                 </observers>
             </sales_quote_product_add_after>
+            <freeproduct_freeitem_loaded>
+                <observers>
+                    <freeproduct>
+                        <class>freeproduct/observer</class>
+                        <method>checkForIgnoredItems</method>
+                    </freeproduct>
+                </observers>
+            </freeproduct_freeitem_loaded>
         </events>
+        <routers>
+            <freeproduct>
+                <use>standard</use>
+                <args>
+                    <module>C4B_Freeproduct</module>
+                    <frontName>freeproduct</frontName>
+                </args>
+            </freeproduct>
+        </routers> 
     </frontend>
 </config>

--- a/app/design/frontend/base/default/template/freeproduct/checkout/cart/item/default.phtml
+++ b/app/design/frontend/base/default/template/freeproduct/checkout/cart/item/default.phtml
@@ -282,6 +282,8 @@ $canApplyMsrp = Mage::helper('catalog')->canApplyMsrp($_item->getProduct(), Mage
     <td class="a-center">
         <?php if (!$_item->getIsFreeProduct()) : ?>    
             <a href="<?php echo $this->getDeleteUrl()?>" title="<?php echo $this->__('Remove item')?>" class="btn-remove btn-remove2"><?php echo $this->__('Remove item')?></a>
+        <?php else: ?>    
+            <a href="<?php echo Mage::helper('freeproduct')->getDeleteUrl($_item); ?>" title="<?php echo $this->__('Remove free item')?>" class="btn-remove btn-remove2"><?php echo $this->__('Remove free item')?></a>
         <?php endif; ?>        
     </td>
 </tr>


### PR DESCRIPTION
Remove button added to cart items which caches the SKUs of any free items that have been automatically added to the cart. 

Made a small modification to the Observer model to add a _checkNotIgnored() function which skips automatically added any free products the user/customer has removed from the cart.